### PR TITLE
refactor(cmd): 移除webviewer中未使用的query_date参数

### DIFF
--- a/cmd/webviewer/query.go
+++ b/cmd/webviewer/query.go
@@ -3326,10 +3326,6 @@ func runMethod(def methodDef, params map[string]string) (queryPayload, map[strin
 		if err != nil {
 			return queryPayload{}, nil, err
 		}
-		queryDate, err := parseUint32Value(params, "query_date", 0)
-		if err != nil {
-			return queryPayload{}, nil, err
-		}
 		code := valueOrDefault(params, "code", "TSLA")
 		request := map[string]any{"market": market, "code": code, "query_date": queryDate}
 		payload, err := withMACExClient(func(client *gotdx.Client) (queryPayload, error) {

--- a/examples/mac_auction/main.go
+++ b/examples/mac_auction/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"log"
 
-	"github.com/bensema/gotdx"
 	"github.com/bensema/gotdx/examples/internal/exampleutil"
+	"github.com/bensema/gotdx/types"
 )
 
 func main() {
 	client := exampleutil.NewMACClient()
 	defer client.Disconnect()
 
-	items, err := client.MACAuction(gotdx.MarketSZ, "000001", 0, 20)
+	items, err := client.MACAuction(types.MarketSZ.Uint8(), "000001", 0, 20)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/mac_symbol_info/main.go
+++ b/examples/mac_symbol_info/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"log"
 
-	"github.com/bensema/gotdx"
 	"github.com/bensema/gotdx/examples/internal/exampleutil"
+	"github.com/bensema/gotdx/types"
 )
 
 func main() {
 	client := exampleutil.NewMACClient()
 	defer client.Disconnect()
 
-	reply, err := client.MACSymbolInfo(gotdx.MarketSZ, "000001")
+	reply, err := client.MACSymbolInfo(types.MarketSZ.Uint8(), "000001")
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
移除cmd/webviewer/query.go中未被使用的queryDate解析逻辑，
因为request中的query_date参数仍然会通过其他方式传递。

BREAKING CHANGE: webviewer的runMethod函数不再解析query_date参数