### PR TITLE
refactor(examples): 更新示例代码中的市场类型引用

### DIFF
--- a/examples/mac_capital_flow/main.go
+++ b/examples/mac_capital_flow/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"log"
 
-	"github.com/bensema/gotdx"
 	"github.com/bensema/gotdx/examples/internal/exampleutil"
+	"github.com/bensema/gotdx/types"
 )
 
 func main() {
 	client := exampleutil.NewMACClient()
 	defer client.Disconnect()
 
-	reply, err := client.MACCapitalFlow(gotdx.MarketSZ, "000001")
+	reply, err := client.MACCapitalFlow(types.MarketSZ.Uint8(), "000001")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/mac_market_monitor/main.go
+++ b/examples/mac_market_monitor/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"log"
 
-	"github.com/bensema/gotdx"
 	"github.com/bensema/gotdx/examples/internal/exampleutil"
+	"github.com/bensema/gotdx/types"
 )
 
 func main() {
 	client := exampleutil.NewMACClient()
 	defer client.Disconnect()
 
-	items, err := client.MACMarketMonitor(gotdx.MarketSZ, 0, 20)
+	items, err := client.MACMarketMonitor(types.MarketSZ.Uint8(), 0, 20)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/mac_symbol_quotes/main.go
+++ b/examples/mac_symbol_quotes/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bensema/gotdx"
 	"github.com/bensema/gotdx/examples/internal/exampleutil"
+	"github.com/bensema/gotdx/types"
 )
 
 func main() {
@@ -12,7 +13,7 @@ func main() {
 	defer client.Disconnect()
 
 	reply, err := client.MACSymbolQuotes(
-		[]uint8{gotdx.MarketSZ, gotdx.MarketSH},
+		[]uint8{types.MarketSZ.Uint8(), types.MarketSH.Uint8()},
 		[]string{"000001", "600000"},
 		gotdx.DefaultMACSymbolQuotesFieldBitmap(),
 	)

--- a/examples/mac_tick_charts/main.go
+++ b/examples/mac_tick_charts/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"log"
 
-	"github.com/bensema/gotdx"
 	"github.com/bensema/gotdx/examples/internal/exampleutil"
+	"github.com/bensema/gotdx/types"
 )
 
 func main() {
 	client := exampleutil.NewMACClient()
 	defer client.Disconnect()
 
-	reply, err := client.MACTickCharts(gotdx.MarketSZ, "000001", 0, 3)
+	reply, err := client.MACTickCharts(types.MarketSZ.Uint8(), "000001", 0, 3)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/mac_transactions/main.go
+++ b/examples/mac_transactions/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"log"
 
-	"github.com/bensema/gotdx"
 	"github.com/bensema/gotdx/examples/internal/exampleutil"
+	"github.com/bensema/gotdx/types"
 )
 
 func main() {
 	client := exampleutil.NewMACClient()
 	defer client.Disconnect()
 
-	items, err := client.MACTransactions(gotdx.MarketSZ, "000001", 0, 20)
+	items, err := client.MACTransactions(types.MarketSZ.Uint8(), "000001", 0, 20)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
- 将 gotdx.MarketSZ 和 gotdx.MarketSH 替换为 types.MarketSZ.Uint8() 和 types.MarketSH.Uint8()
- 添加 github.com/bensema/gotdx/types 导入语句
- 移除不再使用的 github.com/bensema/gotdx 导入语句
- 统一使用 types 包中的市场类型定义