### PR TITLE
feat: 添加全量查询方法

### DIFF
--- a/client_unified.go
+++ b/client_unified.go
@@ -260,6 +260,27 @@ func (client *Client) StockAuction(market uint8, code string, start uint32, coun
 	return reply.List, nil
 }
 
+func (client *Client) StockFullAuction(market uint8, code string) ([]proto.AuctionData, error) {
+	qc, err := client.quotationClient()
+	if err != nil {
+		return nil, err
+	}
+	reply := &proto.GetAuctionReply{}
+	count := uint32(50)
+	for start := uint32(0); ; start += count {
+		res, err := qc.GetAuction(market, code, start, count)
+		if err != nil {
+			return nil, err
+		}
+		reply.Count += res.Count
+		reply.List = append(res.List, reply.List...)
+		if res.Count < uint16(count) {
+			break
+		}
+	}
+	return reply.List, nil
+}
+
 // StockTopBoard 获取主行情排行榜。
 func (client *Client) StockTopBoard(category uint8, size uint8) (*proto.GetTopBoardReply, error) {
 	qc, err := client.quotationClient()
@@ -308,6 +329,27 @@ func (client *Client) StockTransaction(market uint8, code string, start uint16, 
 	return reply.List, nil
 }
 
+func (client *Client) StockFullTransaction(market uint8, code string) ([]proto.TransactionData, error) {
+	qc, err := client.quotationClient()
+	if err != nil {
+		return nil, err
+	}
+	reply := &proto.GetTransactionDataReply{}
+	count := uint16(2000)
+	for start := uint16(0); ; start += count {
+		res, err := qc.GetTransactionData(market, code, start, count)
+		if err != nil {
+			return nil, err
+		}
+		reply.Count += res.Count
+		reply.List = append(res.List, reply.List...)
+		if res.Count < count {
+			break
+		}
+	}
+	return reply.List, nil
+}
+
 // StockHistoryOrders 获取历史委托分布。
 func (client *Client) StockHistoryOrders(date uint32, market uint8, code string) ([]proto.HistoryOrderData, error) {
 	qc, err := client.quotationClient()
@@ -329,6 +371,27 @@ func (client *Client) StockHistoryTransaction(date uint32, market uint8, code st
 	reply, err := qc.GetHistoryTransactionData(date, market, code, start, count)
 	if err != nil {
 		return nil, err
+	}
+	return reply.List, nil
+}
+
+func (client *Client) StockHistoryFullTransaction(date uint32, market uint8, code string) ([]proto.HistoryTransactionData, error) {
+	qc, err := client.quotationClient()
+	if err != nil {
+		return nil, err
+	}
+	reply := &proto.GetHistoryTransactionDataReply{}
+	count := uint16(2000)
+	for start := uint16(0); ; start += count {
+		res, err := qc.GetHistoryTransactionData(date, market, code, start, count)
+		if err != nil {
+			return nil, err
+		}
+		reply.Count += res.Count
+		reply.List = append(res.List, reply.List...)
+		if res.Count < count {
+			break
+		}
 	}
 	return reply.List, nil
 }

--- a/client_unified.go
+++ b/client_unified.go
@@ -345,6 +345,27 @@ func (client *Client) StockHistoryTransactionWithTrans(date uint32, market uint8
 	return reply.List, nil
 }
 
+func (client *Client) StockHistoryFullTransactionWithTrans(date uint32, market uint8, code string) ([]proto.HistoryTransactionDataWithTrans, error) {
+	qc, err := client.quotationClient()
+	if err != nil {
+		return nil, err
+	}
+	reply := &proto.GetHistoryTransactionDataWithTransReply{}
+	count := uint16(2000)
+	for start := uint16(0); ; start += count {
+		res, err := qc.GetHistoryTransactionDataWithTrans(date, market, code, start, count)
+		if err != nil {
+			return nil, err
+		}
+		reply.Count += res.Count
+		reply.List = append(res.List, reply.List...)
+		if res.Count < count {
+			break
+		}
+	}
+	return reply.List, nil
+}
+
 func (client *Client) StockF10(market uint8, code string) (*CompanyInfoBundle, error) {
 	qc, err := client.quotationClient()
 	if err != nil {

--- a/cmd/webviewer/query.go
+++ b/cmd/webviewer/query.go
@@ -4160,7 +4160,7 @@ func rowsFromHistoryTransaction(items []proto.HistoryTransactionData) [][]string
 	rows := make([][]string, 0, len(items))
 	for _, item := range items {
 		rows = append(rows, []string{
-			item.Time,
+			item.Time.Format("2006-01-02 15:04"),
 			formatFloat(item.Price),
 			fmt.Sprintf("%d", item.Vol),
 			fmt.Sprintf("%d", item.Num),

--- a/cmd/webviewer/query.go
+++ b/cmd/webviewer/query.go
@@ -4174,7 +4174,7 @@ func rowsFromHistoryTransactionWithTrans(items []proto.HistoryTransactionDataWit
 	rows := make([][]string, 0, len(items))
 	for _, item := range items {
 		rows = append(rows, []string{
-			item.Time,
+			item.Time.Format("2006-01-02 15:04"),
 			formatFloat(item.Price),
 			fmt.Sprintf("%d", item.Vol),
 			fmt.Sprintf("%d", item.Num),

--- a/examples/stock_history_transaction_with_trans/main.go
+++ b/examples/stock_history_transaction_with_trans/main.go
@@ -11,7 +11,8 @@ func main() {
 	client := exampleutil.NewMainClient()
 	defer client.Disconnect()
 
-	items, err := client.StockHistoryTransactionWithTrans(20260410, types.MarketSZ.Uint8(), "000001", 0, 20)
+	// items, err := client.StockHistoryTransactionWithTrans(20260410, types.MarketSZ.Uint8(), "000001", 0, 20)
+	items, err := client.StockHistoryFullTransactionWithTrans(20260410, types.MarketSZ.Uint8(), "000001")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/proto/get_history_transaction_data.go
+++ b/proto/get_history_transaction_data.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"time"
 )
 
 type GetHistoryTransactionData struct {
@@ -30,13 +31,13 @@ type GetHistoryTransactionDataReply struct {
 }
 
 type HistoryTransactionData struct {
-	Time      string  // 成交时间。
-	Price     float64 // 成交价。
-	Vol       int     // 成交量。
-	Num       int     // 笔数或委托笔数。
-	BuyOrSell int     // 买卖方向标记。
-	Action    string  // 买卖方向，如 BUY/SELL/NEUTRAL。
-	Unknown   int     //  unknown 字段。
+	Time      time.Time // 成交时间。
+	Price     float64   // 成交价。
+	Vol       int       // 成交量。
+	Num       int       // 笔数或委托笔数。
+	BuyOrSell int       // 买卖方向标记。
+	Action    string    // 买卖方向，如 BUY/SELL/NEUTRAL。
+	Unknown   int       //  unknown 字段。
 }
 
 func NewGetHistoryTransactionData(req *GetHistoryTransactionDataRequest) *GetHistoryTransactionData {
@@ -93,8 +94,14 @@ func (obj *GetHistoryTransactionData) ParseResponse(header *RespHeader, data []b
 	lastprice := 0
 	for index := uint16(0); index < obj.reply.Count; index++ {
 		ele := HistoryTransactionData{}
-		h, m := gettime(data, &pos)
-		ele.Time = fmt.Sprintf("%02d:%02d", h, m)
+		hour, minute := gettime(data, &pos)
+		nowDate := fmt.Sprintf("%d", obj.request.Date)
+		hourMinute := fmt.Sprintf("%02d:%02d", hour, minute)
+		nowTime, err := time.ParseInLocation("2006010215:04", nowDate+hourMinute, time.Local)
+		if err != nil {
+			return err
+		}
+		ele.Time = nowTime
 		priceraw := getprice(data, &pos)
 		ele.Vol = getprice(data, &pos)
 		ele.BuyOrSell = getprice(data, &pos)

--- a/proto/get_history_transaction_data_trans.go
+++ b/proto/get_history_transaction_data_trans.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"time"
 )
 
 type GetHistoryTransactionDataWithTrans struct {
@@ -21,11 +22,11 @@ type GetHistoryTransactionDataWithTransReply struct {
 }
 
 type HistoryTransactionDataWithTrans struct {
-	Time   string  // 成交时间。
-	Price  float64 // 成交价。
-	Vol    int     // 成交量。
-	Num    int     // 笔数或委托笔数。
-	Action string  // 成交方向，如 BUY/SELL/NEUTRAL。
+	Time   time.Time // 成交时间。
+	Price  float64   // 成交价。
+	Vol    int       // 成交量。
+	Num    int       // 笔数或委托笔数。
+	Action string    // 成交方向，如 BUY/SELL/NEUTRAL。
 }
 
 func NewGetHistoryTransactionDataWithTrans(req *GetHistoryTransactionDataRequest) *GetHistoryTransactionDataWithTrans {
@@ -80,8 +81,15 @@ func (obj *GetHistoryTransactionDataWithTrans) ParseResponse(header *RespHeader,
 		actionCode := binary.LittleEndian.Uint16(data[pos : pos+2])
 		pos += 2
 		lastPrice += priceDiff
+		// 当前的日期
+		nowDate := fmt.Sprintf("%d", obj.request.Date)
+		hourMinute := fmt.Sprintf("%02d:%02d", hour, minute)
+		nowTime, err := time.ParseInLocation("2006010215:04", nowDate+hourMinute, time.Local)
+		if err != nil {
+			return err
+		}
 		item := HistoryTransactionDataWithTrans{
-			Time:  fmt.Sprintf("%02d:%02d", hour, minute),
+			Time:  nowTime,
 			Price: float64(lastPrice) / baseUnit(string(obj.request.Code[:])),
 			Vol:   vol,
 			Num:   num,

--- a/proto/server_protocol_test.go
+++ b/proto/server_protocol_test.go
@@ -373,7 +373,7 @@ func TestGetHistoryTransactionDataWithTransBuildRequestAndParseResponse(t *testi
 		t.Fatalf("unexpected reply: %+v", reply)
 	}
 	item := reply.List[0]
-	if item.Time != "09:30" || item.Action != "SELL" || math.Abs(item.Price-12.34) > 0.001 {
+	if item.Time.Format("04:05") != "09:30" || item.Action != "SELL" || math.Abs(item.Price-12.34) > 0.001 {
 		t.Fatalf("unexpected item: %+v", item)
 	}
 }

--- a/proto/server_protocol_test.go
+++ b/proto/server_protocol_test.go
@@ -330,7 +330,7 @@ func TestGetHistoryTransactionDataBuildRequestAndParseResponse(t *testing.T) {
 		t.Fatalf("unexpected reply: %+v", reply)
 	}
 	item := reply.List[0]
-	if item.Time != "09:30" || item.Action != "NEUTRAL" || item.Unknown != 7 || item.BuyOrSell != 2 || math.Abs(item.Price-12.34) > 0.001 {
+	if item.Time.Format("04:05") != "09:30" || item.Action != "NEUTRAL" || item.Unknown != 7 || item.BuyOrSell != 2 || math.Abs(item.Price-12.34) > 0.001 {
 		t.Fatalf("unexpected history transaction item: %+v", item)
 	}
 }


### PR DESCRIPTION
feat(client): 新增股票历史逐笔成交全量查询方法
feat(proto): 修改历史交易数据结构体的时间字段类型
feat(webviewer): 格式化历史交易时间显示
feat(example): 更新示例代码以使用完整的股票历史交易数据
test(server_protocol): 修复历史交易数据测试中的时间格式比较
feat(history-transaction): 修改历史交易数据时间字段类型
feat(client): 添加股票完整数据获取功能