### PR TITLE
feat(client): 调整交易数据批量请求的数量限制

### DIFF
--- a/client_unified.go
+++ b/client_unified.go
@@ -335,7 +335,7 @@ func (client *Client) StockFullTransaction(market uint8, code string) ([]proto.T
 		return nil, err
 	}
 	reply := &proto.GetTransactionDataReply{}
-	count := uint16(2000)
+	count := uint16(600)
 	for start := uint16(0); ; start += count {
 		res, err := qc.GetTransactionData(market, code, start, count)
 		if err != nil {
@@ -343,7 +343,7 @@ func (client *Client) StockFullTransaction(market uint8, code string) ([]proto.T
 		}
 		reply.Count += res.Count
 		reply.List = append(res.List, reply.List...)
-		if res.Count < count {
+		if res.Count < count { // 说明已经获取完了
 			break
 		}
 	}
@@ -381,7 +381,7 @@ func (client *Client) StockHistoryFullTransaction(date uint32, market uint8, cod
 		return nil, err
 	}
 	reply := &proto.GetHistoryTransactionDataReply{}
-	count := uint16(2000)
+	count := uint16(600)
 	for start := uint16(0); ; start += count {
 		res, err := qc.GetHistoryTransactionData(date, market, code, start, count)
 		if err != nil {
@@ -414,7 +414,7 @@ func (client *Client) StockHistoryFullTransactionWithTrans(date uint32, market u
 		return nil, err
 	}
 	reply := &proto.GetHistoryTransactionDataWithTransReply{}
-	count := uint16(2000)
+	count := uint16(600)
 	for start := uint16(0); ; start += count {
 		res, err := qc.GetHistoryTransactionDataWithTrans(date, market, code, start, count)
 		if err != nil {


### PR DESCRIPTION
- 将股票实时交易数据请求的批量数量从2000调整为600
- 将历史交易数据请求的批量数量从2000调整为600
- 将带转账记录的历史交易数据请求的批量数量从2000调整为600
- 添加注释说明循环终止条件的业务含义