### PR TITLE
fix(turnover): 修复换手率计算，FloatShares 单位是万股导致结果偏大 10000 倍

### DIFF
--- a/client_unified.go
+++ b/client_unified.go
@@ -1004,7 +1004,7 @@ func (client *Client) loadFloatSharesMap(qc *Client, keys []stockKey) map[stockK
 func applyTurnoverToSecurityQuotes(items []proto.SecurityQuote, shares map[stockKey]float64) {
 	for i := range items {
 		if floatShares := shares[stockKey{Market: items[i].Market, Code: items[i].Code}]; floatShares > 0 {
-			items[i].Turnover = round2(float64(items[i].Vol) * 10000 / floatShares)
+			items[i].Turnover = round2(float64(items[i].Vol) / floatShares)
 		}
 	}
 }
@@ -1012,7 +1012,7 @@ func applyTurnoverToSecurityQuotes(items []proto.SecurityQuote, shares map[stock
 func applyTurnoverToQuoteList(items []proto.QuoteListItem, shares map[stockKey]float64) {
 	for i := range items {
 		if floatShares := shares[stockKey{Market: items[i].Market, Code: items[i].Code}]; floatShares > 0 {
-			items[i].Turnover = round2(float64(items[i].Vol) * 10000 / floatShares)
+			items[i].Turnover = round2(float64(items[i].Vol) / floatShares)
 		}
 	}
 }
@@ -1022,7 +1022,7 @@ func applyTurnoverToBars(items []proto.SecurityBar, floatShares float64) {
 		return
 	}
 	for i := range items {
-		items[i].Turnover = round2(items[i].Vol * 100 / floatShares)
+		items[i].Turnover = round2(items[i].Vol * 100 / (floatShares * 10000))
 	}
 }
 
@@ -1030,7 +1030,7 @@ func applyTurnoverToVolumeProfile(reply *proto.GetVolumeProfileReply, floatShare
 	if reply == nil || floatShares <= 0 {
 		return
 	}
-	reply.Turnover = round2(float64(reply.Vol) * 10000 / floatShares)
+	reply.Turnover = round2(float64(reply.Vol) / floatShares)
 }
 
 func round2(v float64) float64 {

--- a/client_unified.go
+++ b/client_unified.go
@@ -157,7 +157,7 @@ func (client *Client) StockKLine930(category uint16, market uint8, code string, 
 					// 当前数据是不是当前交易日
 					data := proto.SecurityBar{}
 					if cast.ToUint32(v.DateTime.Format("20060102")) == info.Date {
-						if trans, err := client.StockFullTransaction(market, code); err == nil {
+						if trans, err := client.StockTransaction(market, code, 0, 1); err == nil {
 							data.Open = trans[0].Price
 							data.High = trans[0].Price
 							data.Low = trans[0].Price
@@ -172,7 +172,7 @@ func (client *Client) StockKLine930(category uint16, market uint8, code string, 
 							list = append(list, data)
 						}
 					} else {
-						if trans, err := client.StockHistoryFullTransaction(cast.ToUint32(v.DateTime.Format("20060102")), market, code); err == nil {
+						if trans, err := client.StockHistoryTransaction(cast.ToUint32(v.DateTime.Format("20060102")), market, code, 0, 1); err == nil {
 							// if len(trans) > 0 && trans[0].Time.Format(time.TimeOnly) < "09:30:00" {
 							data.Open = trans[0].Price
 							data.High = trans[0].Price

--- a/client_unified_test.go
+++ b/client_unified_test.go
@@ -77,42 +77,42 @@ func TestNewMACExUsesMacExAddressAsPrimary(t *testing.T) {
 
 func TestApplyTurnoverHelpers(t *testing.T) {
 	shares := map[stockKey]float64{
-		{Market: types.MarketSZ.Uint8(), Code: "000001"}: 1000000,
+		{Market: types.MarketSZ.Uint8(), Code: "000001"}: 100000,
 	}
 
 	quotes := []proto.SecurityQuote{{
 		Market: types.MarketSZ.Uint8(),
 		Code:   "000001",
-		Vol:    12345,
+		Vol:    100000,
 	}}
 	applyTurnoverToSecurityQuotes(quotes, shares)
-	if quotes[0].Turnover != 123.45 {
+	if quotes[0].Turnover != 1.0 {
 		t.Fatalf("unexpected security quote turnover: %.2f", quotes[0].Turnover)
 	}
 
 	quoteList := []proto.QuoteListItem{{
 		Market: types.MarketSZ.Uint8(),
 		Code:   "000001",
-		Vol:    23456,
+		Vol:    150000,
 	}}
 	applyTurnoverToQuoteList(quoteList, shares)
-	if quoteList[0].Turnover != 234.56 {
+	if quoteList[0].Turnover != 1.5 {
 		t.Fatalf("unexpected quote list turnover: %.2f", quoteList[0].Turnover)
 	}
 
-	bars := []proto.SecurityBar{{Vol: 12345}}
-	applyTurnoverToBars(bars, 1000000)
-	if bars[0].Turnover != 1.23 {
+	bars := []proto.SecurityBar{{Vol: 2000000}}
+	applyTurnoverToBars(bars, 2000)
+	if bars[0].Turnover != 10.0 {
 		t.Fatalf("unexpected bar turnover: %.2f", bars[0].Turnover)
 	}
 
 	reply := &proto.GetVolumeProfileReply{
 		Market: types.MarketSZ.Uint8(),
 		Code:   "000001",
-		Vol:    34567,
+		Vol:    200000,
 	}
-	applyTurnoverToVolumeProfile(reply, 1000000)
-	if reply.Turnover != 345.67 {
+	applyTurnoverToVolumeProfile(reply, 100000)
+	if reply.Turnover != 2.0 {
 		t.Fatalf("unexpected volume profile turnover: %.2f", reply.Turnover)
 	}
 }


### PR DESCRIPTION
修复换手率计算中 FloatShares 单位问题。

## 问题
FloatShares（流通股本）来自通达信协议，单位是**万股**，但代码按**股**计算，导致 Turnover 结果偏大 10000 倍。例如实际换手率 0.44% 被返回为 4369.56。MAC 代码 `items[i].Turnover = round2(items[i].Vol / (items[i].FloatShares * 10000) * 100)` 中确认 FloatShares 是万股，故作此修改。

## 修改
- applyTurnoverToBars：Vol（股）x 100 / (FloatShares(万股) x 10000)
- applyTurnoverToSecurityQuotes：Vol（手）/ FloatShares(万股)
- applyTurnoverToQuoteList：同上
- applyTurnoverToVolumeProfile：同上

## 验证
1. 后端数据：
<img width="2091" height="1255" alt="image" src="https://github.com/user-attachments/assets/fc128884-e7dd-4bc8-b5a5-65f1a4cd86c0" />
2. 同花顺数据二次确认：
<img width="2002" height="972" alt="image" src="https://github.com/user-attachments/assets/163c87c3-71b9-4930-8995-238d7e42a8a9" />


Closes #26