### PR TITLE
fix(proto): 修复K线数据解析中的日期验证逻辑

### DIFF
--- a/proto/ex_kline.go
+++ b/proto/ex_kline.go
@@ -94,7 +94,7 @@ func (obj *ExGetKLine) ParseResponse(header *RespHeader, data []byte) error {
 			return fmt.Errorf("invalid ex kline item %d", i)
 		}
 		dateNum := binary.LittleEndian.Uint32(data[pos : pos+4])
-		ts, ok := decodeDateNum(obj.reply.Period, dateNum)
+		ts, ok := decodeDateNum(obj.reply.Period, dateNum, false)
 		if !ok {
 			return fmt.Errorf("invalid ex kline datetime: %d", dateNum)
 		}

--- a/proto/experimental.go
+++ b/proto/experimental.go
@@ -586,7 +586,7 @@ func (obj *ExGetKLine2) ParseResponse(header *RespHeader, data []byte) error {
 			return fmt.Errorf("invalid ex kline2 item %d", i)
 		}
 		dateNum := binary.LittleEndian.Uint32(data[pos : pos+4])
-		ts, ok := decodeDateNum(obj.reply.Period, dateNum)
+		ts, ok := decodeDateNum(obj.reply.Period, dateNum, false)
 		if !ok {
 			return fmt.Errorf("invalid ex kline2 datetime: %d", dateNum)
 		}

--- a/proto/get_index_bars.go
+++ b/proto/get_index_bars.go
@@ -96,7 +96,7 @@ func (obj *GetIndexBars) ParseResponse(header *RespHeader, data []byte) error {
 		}
 		pos += 4
 
-		dateTime, ok := decodeDateNum(obj.request.Category, dateNum)
+		dateTime, ok := decodeDateNum(obj.request.Category, dateNum, true)
 		if !ok {
 			return fmt.Errorf("invalid kline datetime: %d", dateNum)
 		}
@@ -125,7 +125,7 @@ func (obj *GetIndexBars) ParseResponse(header *RespHeader, data []byte) error {
 
 		if pos+4 <= len(data) {
 			tryDateNum := binary.LittleEndian.Uint32(data[pos : pos+4])
-			if _, ok := decodeDateNum(obj.request.Category, tryDateNum); !ok {
+			if _, ok := decodeDateNum(obj.request.Category, tryDateNum, true); !ok {
 				bar.UpCount = binary.LittleEndian.Uint16(data[pos : pos+2])
 				bar.DownCount = binary.LittleEndian.Uint16(data[pos+2 : pos+4])
 				pos += 4

--- a/proto/get_security_bars.go
+++ b/proto/get_security_bars.go
@@ -107,7 +107,7 @@ func (obj *GetSecurityBars) ParseResponse(header *RespHeader, data []byte) error
 		}
 		pos += 4
 
-		dateTime, ok := decodeDateNum(obj.request.Category, dateNum)
+		dateTime, ok := decodeDateNum(obj.request.Category, dateNum, false)
 		if !ok {
 			return fmt.Errorf("invalid kline datetime: %d", dateNum)
 		}
@@ -151,7 +151,7 @@ func (obj *GetSecurityBars) ParseResponse(header *RespHeader, data []byte) error
 
 		if pos+4 <= len(data) {
 			tryDateNum := binary.LittleEndian.Uint32(data[pos : pos+4])
-			if _, ok := decodeDateNum(obj.request.Category, tryDateNum); !ok {
+			if _, ok := decodeDateNum(obj.request.Category, tryDateNum, false); !ok {
 				bar.UpCount = binary.LittleEndian.Uint16(data[pos : pos+2])
 				bar.DownCount = binary.LittleEndian.Uint16(data[pos+2 : pos+4])
 				pos += 4

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -262,7 +262,7 @@ func DecodeSecond(num uint32) time.Time {
 	return epoch.Add(time.Duration(num) * time.Second)
 }
 
-func decodeDateNum(category uint16, num uint32) (time.Time, bool) {
+func decodeDateNum(category uint16, num uint32, index bool) (time.Time, bool) {
 	minuteCategory := category < 4 || category == 7 || category == 8
 	isSecond := category == 13
 	year, month, day := 0, 0, 0
@@ -286,16 +286,18 @@ func decodeDateNum(category uint16, num uint32) (time.Time, bool) {
 	if isSecond {
 		return DecodeSecond(num), true
 	}
+	if index {
 
-	// if year < 1992 || year > time.Now().Year()+1 {
-	// 	return time.Time{}, false
-	// }
-	// if month < 1 || month > 12 || day < 1 || day > 31 {
-	// 	return time.Time{}, false
-	// }
-	// if hour < 0 || hour > 23 || minute < 0 || minute > 59 {
-	// 	return time.Time{}, false
-	// }
+		if year < 1992 || year > time.Now().Year()+1 {
+			return time.Time{}, false
+		}
+		if month < 1 || month > 12 || day < 1 || day > 31 {
+			return time.Time{}, false
+		}
+		if hour < 0 || hour > 23 || minute < 0 || minute > 59 {
+			return time.Time{}, false
+		}
+	}
 
 	t := time.Date(year, time.Month(month), day, hour, minute, second, 0, time.Local)
 


### PR DESCRIPTION
为decodeDateNum函数添加index参数来区分指数和股票数据的不同验证规则，
确保指数数据进行严格的日期范围检查而股票数据跳过这些检查以保持兼容性。

close #28 