### PR TITLE
feat(mac): 更新MAC协议时间字段为time.Time类型并添加涨跌幅计算

### DIFF
--- a/client_mac.go
+++ b/client_mac.go
@@ -655,9 +655,6 @@ func (client *Client) MACMarketMonitor(market uint8, start uint32, count uint32)
 }
 
 func (client *Client) MACSymbolBars(market uint8, code string, period uint16, times uint16, start uint32, count uint32, adjust uint16) ([]proto.MACSymbolBar, error) {
-	if count == 0 {
-		count = DefaultMACSymbolBarsCount
-	}
 	if err := client.ConnectMAC(); err != nil {
 		return nil, err
 	}

--- a/client_mac_integration_test.go
+++ b/client_mac_integration_test.go
@@ -2,6 +2,7 @@ package gotdx
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bensema/gotdx/types"
 )
@@ -34,7 +35,7 @@ func Test_tdx_MACRecentProtocols(t *testing.T) {
 		if len(reply.ChartData) == 0 {
 			t.Fatalf("expected historical chart data, got empty reply: %+v", reply)
 		}
-		if reply.DateTime == "" {
+		if reply.DateTime.Format(time.DateTime) == "" {
 			t.Fatalf("expected quote summary datetime, got empty reply: %+v", reply)
 		}
 	})
@@ -122,7 +123,7 @@ func Test_tdx_MACRecentProtocols(t *testing.T) {
 		if err != nil {
 			t.Fatalf("MACTickCharts failed: %v", err)
 		}
-		if reply.Code != "000001" || reply.DateTime == "" {
+		if reply.Code != "000001" || reply.DateTime.Format(time.DateTime) == "" {
 			t.Fatalf("unexpected tick charts reply: %+v", reply)
 		}
 		if len(reply.Charts) == 0 || reply.Total == 0 {

--- a/cmd/webviewer/query.go
+++ b/cmd/webviewer/query.go
@@ -4894,7 +4894,7 @@ func rowsFromMACSymbolInfo(reply *proto.MACSymbolInfoReply) [][]string {
 		fmt.Sprintf("%d", reply.Market),
 		reply.Code,
 		reply.Name,
-		reply.DateTime,
+		reply.DateTime.Format(time.DateTime),
 		fmt.Sprintf("%d", reply.Activity),
 		formatFloat(reply.PreClose),
 		formatFloat(reply.Open),
@@ -4959,7 +4959,7 @@ func rowsFromMACSymbolBars(items []proto.MACSymbolBar) [][]string {
 	rows := make([][]string, 0, len(items))
 	for _, item := range items {
 		rows = append(rows, []string{
-			item.DateTime,
+			item.DateTime.Format(time.DateTime),
 			formatFloat(item.Open),
 			formatFloat(item.High),
 			formatFloat(item.Low),

--- a/cmd/webviewer/query_test.go
+++ b/cmd/webviewer/query_test.go
@@ -208,7 +208,7 @@ func TestRowsFromMACQuoteChart(t *testing.T) {
 
 func TestRowsFromMACSymbolBarsIncludesTurnover(t *testing.T) {
 	rows := rowsFromMACSymbolBars([]proto.MACSymbolBar{{
-		DateTime:    "2026-04-12 15:00:00",
+		DateTime:    time.Now(),
 		Open:        10,
 		High:        11,
 		Low:         9,

--- a/proto/mac_protocol_test.go
+++ b/proto/mac_protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"math"
 	"testing"
+	"time"
 )
 
 func assertNearFloat64(t *testing.T, got float64, want float64, label string) {
@@ -1119,7 +1120,7 @@ func TestMACTickChartsBuildRequestAndParseResponse(t *testing.T) {
 	if reply.Charts[0].Date != "2026-04-18" || len(reply.Charts[0].Ticks) != 2 || reply.Charts[1].Ticks[1].Unknown != 10 {
 		t.Fatalf("unexpected charts: %+v", reply.Charts)
 	}
-	if reply.Name != "PingAn Bank" || reply.DateTime != "2026-04-18 15:00:05" || reply.Industry != 83005 || reply.IndustryCode != "881282" {
+	if reply.Name != "PingAn Bank" || reply.DateTime.Format(time.DateTime) != "2026-04-18 15:00:05" || reply.Industry != 83005 || reply.IndustryCode != "881282" {
 		t.Fatalf("unexpected summary: %+v", reply)
 	}
 	assertNearFloat64(t, reply.Charts[0].PreClose, 10.0, "tick_day_pre_close_0")
@@ -1314,7 +1315,7 @@ func TestMACSymbolInfoBuildRequestAndParseResponse(t *testing.T) {
 		t.Fatalf("parse response failed: %v", err)
 	}
 	reply := msg.Response()
-	if reply.Market != 1 || reply.Code != "600000" || reply.Name != "PingAn Bank" || reply.DateTime != "2026-04-18 15:00:05" {
+	if reply.Market != 1 || reply.Code != "600000" || reply.Name != "PingAn Bank" || reply.DateTime.Format(time.DateTime) != "2026-04-18 15:00:05" {
 		t.Fatalf("unexpected reply: %+v", reply)
 	}
 	if reply.Activity != 321 || reply.Vol != 220 || reply.InsideVolume != 100 || reply.OutsideVolume != 120 || reply.Decimal != 2 || reply.UnknownA != 11 || reply.UnknownC != 33 {
@@ -1631,10 +1632,10 @@ func TestMACSymbolBarsBuildRequestAndParseResponse(t *testing.T) {
 		t.Fatalf("unexpected reply: %+v", reply)
 	}
 	item := reply.List[0]
-	if item.DateTime != "2026-03-31 09:30:00" || math.Abs(item.Close-10.5) > 0.001 || math.Abs(item.Vol-789.0) > 0.001 {
+	if item.DateTime.Format(time.DateTime) != "2026-03-31 09:30:00" || math.Abs(item.Close-10.5) > 0.001 || math.Abs(item.Vol-789.0) > 0.001 {
 		t.Fatalf("unexpected symbol bar: %+v", item)
 	}
-	if reply.Name != "PingAn Bank" || reply.DateTime != "2026-03-31 15:00:05" || reply.Industry != 83005 || reply.IndustryCode != "881282" {
+	if reply.Name != "PingAn Bank" || reply.DateTime.Format(time.DateTime) != "2026-03-31 15:00:05" || reply.Industry != 83005 || reply.IndustryCode != "881282" {
 		t.Fatalf("unexpected symbol bar summary: %+v", reply)
 	}
 }

--- a/proto/mac_quotes.go
+++ b/proto/mac_quotes.go
@@ -31,19 +31,18 @@ type MACQuotesRequest struct {
 
 // MACQuotesReply 表示 MAC 单只行情快照及分时采样响应。
 type MACQuotesReply struct {
-	Market    uint16
-	Code      string
-	Date      uint32
-	Unknown   uint8
-	Price     float64
-	Count     uint16
-	ChartData []MACQuoteChartItem
-
+	Market       uint16
+	Code         string
+	Date         uint32
+	Unknown      uint8
+	Price        float64
+	Count        uint16
+	ChartData    []MACQuoteChartItem
 	Name         string
 	Decimal      uint8
 	Category     uint16
 	VolUnit      float64
-	DateTime     string
+	DateTime     time.Time
 	PreClose     float64
 	Open         float64
 	High         float64
@@ -163,12 +162,12 @@ func (obj *MACQuotes) Response() *MACQuotesReply {
 	return obj.reply
 }
 
-func formatMACQuoteDateTime(dateRaw uint32, timeRaw uint32) string {
+func formatMACQuoteDateTime(dateRaw uint32, timeRaw uint32) time.Time {
 	year := int(dateRaw / 10000)
 	month := int((dateRaw % 10000) / 100)
 	day := int(dateRaw % 100)
 	hour := int(timeRaw / 10000)
 	minute := int((timeRaw % 10000) / 100)
 	second := int(timeRaw % 100)
-	return time.Date(year, time.Month(month), day, hour, minute, second, 0, time.Local).Format("2006-01-02 15:04:05")
+	return time.Date(year, time.Month(month), day, hour, minute, second, 0, time.Local)
 }

--- a/proto/mac_symbol_bars.go
+++ b/proto/mac_symbol_bars.go
@@ -32,19 +32,18 @@ type MACSymbolBarsRequest struct {
 }
 
 type MACSymbolBarsReply struct {
-	Market  uint16
-	Code    string
-	Period  uint8
-	Unknown uint16
-	Count   uint16
-	Start   uint32
-	List    []MACSymbolBar
-
+	Market       uint16
+	Code         string
+	Period       uint8
+	Unknown      uint16
+	Count        uint16
+	Start        uint32
+	List         []MACSymbolBar
 	Name         string
 	Decimal      uint8
 	Category     uint16
 	VolUnit      float64
-	DateTime     string
+	DateTime     time.Time
 	PreClose     float64
 	Open         float64
 	High         float64
@@ -60,7 +59,7 @@ type MACSymbolBarsReply struct {
 }
 
 type MACSymbolBar struct {
-	DateTime    string
+	DateTime    time.Time
 	Open        float64
 	High        float64
 	Low         float64
@@ -69,6 +68,9 @@ type MACSymbolBar struct {
 	Vol         float64
 	FloatShares float64
 	Turnover    float64
+	Last        float64
+	RisePrice   float64 // 涨跌价
+	RiseRate    float64 // 涨跌幅
 }
 
 func NewMACSymbolBars(req *MACSymbolBarsRequest) *MACSymbolBars {
@@ -83,7 +85,6 @@ func NewMACSymbolBars(req *MACSymbolBarsRequest) *MACSymbolBars {
 	obj.reqHeader.PacketType = 0x01
 	obj.reqHeader.Method = KMSG_MACSYMBOLBARS
 	obj.request.Times = 1
-	obj.request.Count = 700
 	obj.request.Flag1 = 1
 	obj.request.Flag2 = 1
 	obj.request.Flag4 = 1
@@ -97,9 +98,6 @@ func (obj *MACSymbolBars) applyRequest(req *MACSymbolBarsRequest) {
 	if req.Times == 0 {
 		req.Times = 1
 	}
-	if req.Count == 0 {
-		req.Count = 700
-	}
 	if req.Flag1 == 0 {
 		req.Flag1 = 1
 	}
@@ -109,6 +107,7 @@ func (obj *MACSymbolBars) applyRequest(req *MACSymbolBarsRequest) {
 	if req.Flag4 == 0 {
 		req.Flag4 = 1
 	}
+	req.Count = req.Count + 1
 	obj.request = req
 }
 
@@ -134,8 +133,8 @@ func (obj *MACSymbolBars) ParseResponse(header *RespHeader, data []byte) error {
 	obj.reply.Start = binary.LittleEndian.Uint32(data[29:33])
 
 	formatTDXTime := obj.reply.Period < 4 || obj.reply.Period == 7 || obj.reply.Period == 8
-
 	pos := 33
+	var lastRaw float64 // 昨收盘价
 	for i := uint16(0); i < obj.reply.Count; i++ {
 		if pos+36 > len(data) {
 			return fmt.Errorf("invalid mac symbol bar item %d", i)
@@ -143,7 +142,7 @@ func (obj *MACSymbolBars) ParseResponse(header *RespHeader, data []byte) error {
 		ymd := binary.LittleEndian.Uint32(data[pos : pos+4])
 		seconds := binary.LittleEndian.Uint32(data[pos+4 : pos+8])
 		item := MACSymbolBar{
-			DateTime:    combineMACDateTime(ymd, seconds, formatTDXTime).Format("2006-01-02 15:04:05"),
+			DateTime:    combineMACDateTime(ymd, seconds, formatTDXTime),
 			Open:        float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+8 : pos+12]))),
 			High:        float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+12 : pos+16]))),
 			Low:         float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+16 : pos+20]))),
@@ -152,9 +151,17 @@ func (obj *MACSymbolBars) ParseResponse(header *RespHeader, data []byte) error {
 			Vol:         float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+28 : pos+32]))),
 			FloatShares: float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+32 : pos+36]))),
 		}
-		obj.reply.List = append(obj.reply.List, item)
+		item.Last = lastRaw
+		lastRaw = item.Close
+		item.RiseRate = item.GetRiseRate()
+		item.RisePrice = item.GetRisePrice()
 		pos += 36
+		if i == 0 {
+			continue
+		}
+		obj.reply.List = append(obj.reply.List, item)
 	}
+	obj.reply.Count = obj.reply.Count - 1
 
 	if pos+120 > len(data) {
 		return nil
@@ -181,6 +188,22 @@ func (obj *MACSymbolBars) ParseResponse(header *RespHeader, data []byte) error {
 	obj.reply.IndustryCode = macIndustryBoardSymbol(obj.reply.Industry)
 
 	return nil
+}
+
+func (bar MACSymbolBar) GetRisePrice() float64 {
+	if bar.Last == 0 {
+		//稍微数据准确点，没减去0这么夸张，还是不准的
+		return bar.Close - bar.Open
+	}
+	return bar.Close - bar.Last
+}
+
+// RiseRate 涨跌比例/涨跌幅
+func (bar MACSymbolBar) GetRiseRate() float64 {
+	if bar.Last == 0 {
+		return (bar.Close - bar.Open) / (bar.Open) * 100
+	}
+	return (bar.Close - bar.Last) / (bar.Last) * 100
 }
 
 func (obj *MACSymbolBars) Response() *MACSymbolBarsReply {

--- a/proto/mac_symbol_info.go
+++ b/proto/mac_symbol_info.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"time"
 )
 
 // MACSymbolInfo 表示 0x122A MAC 股票摘要协议。
@@ -28,7 +29,7 @@ type MACSymbolInfoReply struct {
 	Market        uint16
 	Code          string
 	Name          string
-	DateTime      string
+	DateTime      time.Time
 	Activity      uint32
 	PreClose      float64
 	Open          float64

--- a/proto/mac_tick_charts.go
+++ b/proto/mac_tick_charts.go
@@ -28,19 +28,18 @@ type MACTickChartsRequest struct {
 
 // MACTickChartsReply 表示 MAC 多日分时响应。
 type MACTickChartsReply struct {
-	Market   uint16
-	Code     string
-	Count    uint16
-	SendLast uint8
-	PageSize uint16
-	Total    uint16
-	Charts   []MACTickChartDay
-
+	Market       uint16
+	Code         string
+	Count        uint16
+	SendLast     uint8
+	PageSize     uint16
+	Total        uint16
+	Charts       []MACTickChartDay
 	Name         string
 	Decimal      uint8
 	Category     uint16
 	VolUnit      float64
-	DateTime     string
+	DateTime     time.Time
 	PreClose     float64
 	Open         float64
 	High         float64


### PR DESCRIPTION
- 将MACQuotesReply、MACSymbolBarsReply、MACSymbolInfoReply和MACTickChartsReply 中的DateTime字段从string类型改为time.Time类型
- 修改formatMACQuoteDateTime函数返回time.Time类型
- 在MACSymbolBar结构体中添加Last、RisePrice和RiseRate字段用于涨跌计算
- 实现GetRisePrice和GetRiseRate方法计算涨跌价格和涨跌比例
- 调整MACSymbolBars请求处理逻辑，移除默认count值设置并修改计数逻辑
- 更新相关测试文件中的时间格式化代码以适配time.Time类型
- 添加time包导入以支持时间操作

BREAKING CHANGE: DateTime字段类型从string改为time.Time，需要相应调整调用代码