### PR TITLE
feat(proto): 添加K线数据中的昨收盘价、涨跌价和涨跌幅字段

### DIFF
--- a/client_unified.go
+++ b/client_unified.go
@@ -162,11 +162,11 @@ func (client *Client) StockKLine930(category uint16, market uint8, code string, 
 							data.High = trans[0].Price
 							data.Low = trans[0].Price
 							data.Close = trans[0].Price
-							data.Last = v.Last
+							data.PreClose = v.PreClose
 							data.Vol = cast.ToFloat64(trans[0].Vol)
 							data.Amount = cast.ToFloat64(trans[0].Vol) * trans[0].Price * 100
 							data.DateTime = time.Date(v.DateTime.Year(), v.DateTime.Month(), v.DateTime.Day(), 9, 30, 0, 0, v.DateTime.Location())
-							v.Last = trans[0].Price
+							v.PreClose = trans[0].Price
 							data.RiseRate = data.GetRiseRate()
 							data.RisePrice = data.GetRisePrice()
 							list = append(list, data)
@@ -178,11 +178,11 @@ func (client *Client) StockKLine930(category uint16, market uint8, code string, 
 							data.High = trans[0].Price
 							data.Low = trans[0].Price
 							data.Close = trans[0].Price
-							data.Last = v.Last
+							data.PreClose = v.PreClose
 							data.Vol = cast.ToFloat64(trans[0].Vol)
 							data.Amount = cast.ToFloat64(trans[0].Vol) * trans[0].Price * 100
 							data.DateTime = time.Date(v.DateTime.Year(), v.DateTime.Month(), v.DateTime.Day(), 9, 30, 0, 0, v.DateTime.Location())
-							v.Last = trans[0].Price
+							v.PreClose = trans[0].Price
 							data.RiseRate = data.GetRiseRate()
 							data.RisePrice = data.GetRisePrice()
 							list = append(list, data)

--- a/cmd/webviewer/query.go
+++ b/cmd/webviewer/query.go
@@ -4101,7 +4101,7 @@ func rowsFromSecurityBars(items []proto.SecurityBar) [][]string {
 	for _, item := range items {
 		rows = append(rows, []string{
 			item.DateTime.Format(time.DateTime),
-			formatFloat(item.Last),
+			formatFloat(item.PreClose),
 			formatFloat(item.Open),
 			formatFloat(item.High),
 			formatFloat(item.Low),
@@ -4511,7 +4511,7 @@ func rowsFromExKLine(items []proto.ExKLineItem) [][]string {
 	for _, item := range items {
 		rows = append(rows, []string{
 			item.DateTime.Format(time.DateTime),
-			formatFloat(item.Last),
+			formatFloat(item.PreClose),
 			formatFloat(item.Open),
 			formatFloat(item.High),
 			formatFloat(item.Low),

--- a/cmd/webviewer/query.go
+++ b/cmd/webviewer/query.go
@@ -2641,7 +2641,7 @@ func runMethod(def methodDef, params map[string]string) (queryPayload, map[strin
 				return queryPayload{}, err
 			}
 			return queryPayload{
-				columns: []string{"datetime", "open", "high", "low", "close", "vol", "amount"},
+				columns: []string{"datetime", "last", "open", "high", "low", "close", "vol", "amount"},
 				rows:    rowsFromExKLine(reply.List),
 				raw:     reply.List,
 			}, nil
@@ -4510,7 +4510,8 @@ func rowsFromExKLine(items []proto.ExKLineItem) [][]string {
 	rows := make([][]string, 0, len(items))
 	for _, item := range items {
 		rows = append(rows, []string{
-			item.DateTime,
+			item.DateTime.Format(time.DateTime),
+			formatFloat(item.Last),
 			formatFloat(item.Open),
 			formatFloat(item.High),
 			formatFloat(item.Low),

--- a/examples/stock_index_tools/main.go
+++ b/examples/stock_index_tools/main.go
@@ -12,20 +12,20 @@ func main() {
 	client := exampleutil.NewMainClient()
 	defer client.Disconnect()
 
-	info, err := client.StockIndexInfo(types.MarketSZ.Uint8(), "399001")
+	info, err := client.StockIndexInfo(types.MarketSH.Uint8(), "000001")
 	if err != nil {
 		log.Fatalln(err)
 	}
 	log.Printf("index_info code=%s time=%s close=%.2f open=%.2f high=%.2f low=%.2f up=%d down=%d",
 		info.Code, info.ServerTime, info.Close, info.Open, info.High, info.Low, info.UpCount, info.DownCount)
 
-	momentum, err := client.StockIndexMomentum(types.MarketSZ.Uint8(), "399001")
+	momentum, err := client.StockIndexMomentum(types.MarketSH.Uint8(), "000001")
 	if err != nil {
 		log.Fatalln(err)
 	}
 	log.Printf("index_momentum count=%d last=%d", len(momentum), momentum[len(momentum)-1])
 
-	bars, err := client.GetIndexBars(types.KLINE_TYPE_DAILY, types.MarketSZ.Uint8(), "399001", 0, 5)
+	bars, err := client.GetIndexBars(types.KLINE_TYPE_DAILY, types.MarketSH.Uint8(), "000001", 0, 5)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/stock_kline/main.go
+++ b/examples/stock_kline/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	for _, bar := range bars {
-		log.Printf("%s last=%.3f open=%.3f high=%.3f low=%.3f close=%.3f rate=%.2f  price=%.2f vol=%.0f amount=%.0f turnover=%.2f%%",
-			bar.DateTime, bar.Last, bar.Open, bar.High, bar.Low, bar.Close, bar.RiseRate, bar.RisePrice, bar.Vol, bar.Amount, bar.Turnover)
+		log.Printf("%s preClose=%.3f open=%.3f high=%.3f low=%.3f close=%.3f rate=%.2f  price=%.2f vol=%.0f amount=%.0f turnover=%.2f%%",
+			bar.DateTime, bar.PreClose, bar.Open, bar.High, bar.Low, bar.Close, bar.RiseRate, bar.RisePrice, bar.Vol, bar.Amount, bar.Turnover)
 	}
 }

--- a/proto/ex_kline.go
+++ b/proto/ex_kline.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"time"
 )
 
 type ExGetKLine struct {
@@ -34,13 +35,16 @@ type ExGetKLineReply struct {
 }
 
 type ExKLineItem struct {
-	DateTime string
-	Open     float64
-	High     float64
-	Low      float64
-	Close    float64
-	Amount   float64
-	Vol      uint32
+	DateTime  time.Time
+	Open      float64
+	High      float64
+	Low       float64
+	Close     float64
+	Amount    float64
+	Vol       uint32
+	Last      float64 // 昨收盘价
+	RisePrice float64 // 涨跌价
+	RiseRate  float64 // 涨跌幅
 }
 
 func NewExGetKLine(req *ExGetKLineRequest) *ExGetKLine {
@@ -54,6 +58,7 @@ func NewExGetKLine(req *ExGetKLineRequest) *ExGetKLine {
 	obj.reqHeader.SeqID = seqID()
 	obj.reqHeader.PacketType = 0x01
 	obj.reqHeader.Method = KMSG_EXKLINE
+	req.Count = req.Count + 1
 	if req != nil {
 		obj.applyRequest(req)
 	}
@@ -89,6 +94,8 @@ func (obj *ExGetKLine) ParseResponse(header *RespHeader, data []byte) error {
 	obj.reply.Count = binary.LittleEndian.Uint16(data[18:20])
 	pos := 20
 
+	var lastRaw float64 // 昨收盘价
+
 	for i := uint16(0); i < obj.reply.Count; i++ {
 		if pos+32 > len(data) {
 			return fmt.Errorf("invalid ex kline item %d", i)
@@ -99,7 +106,7 @@ func (obj *ExGetKLine) ParseResponse(header *RespHeader, data []byte) error {
 			return fmt.Errorf("invalid ex kline datetime: %d", dateNum)
 		}
 		item := ExKLineItem{
-			DateTime: ts.Format("2006-01-02 15:04:05"),
+			DateTime: ts,
 			Open:     float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+4 : pos+8]))),
 			High:     float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+8 : pos+12]))),
 			Low:      float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+12 : pos+16]))),
@@ -107,10 +114,34 @@ func (obj *ExGetKLine) ParseResponse(header *RespHeader, data []byte) error {
 			Amount:   float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+20 : pos+24]))),
 			Vol:      binary.LittleEndian.Uint32(data[pos+24 : pos+28]),
 		}
-		obj.reply.List = append(obj.reply.List, item)
+		item.Last = float64(lastRaw)
+		lastRaw = float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+16 : pos+20])))
+		item.RiseRate = item.GetRiseRate()
+		item.RisePrice = item.GetRisePrice()
 		pos += 32
+		if i == 0 {
+			continue
+		}
+		obj.reply.List = append(obj.reply.List, item)
 	}
+	obj.reply.Count = obj.reply.Count - 1
 	return nil
+}
+
+func (bar ExKLineItem) GetRisePrice() float64 {
+	if bar.Last == 0 {
+		//稍微数据准确点，没减去0这么夸张，还是不准的
+		return bar.Close - bar.Open
+	}
+	return bar.Close - bar.Last
+}
+
+// RiseRate 涨跌比例/涨跌幅
+func (bar ExKLineItem) GetRiseRate() float64 {
+	if bar.Last == 0 {
+		return float64(bar.Close-bar.Open) / float64(bar.Open) * 100
+	}
+	return float64(bar.Close-bar.Last) / float64(bar.Last) * 100
 }
 
 func (obj *ExGetKLine) Response() *ExGetKLineReply {
@@ -128,7 +159,8 @@ type ExGetHistoryTransactionRequest struct {
 	Date     uint32
 	Category uint8
 	Code     [43]byte
-	Count    uint16
+	// Start    uint32
+	Count uint16
 }
 
 type ExGetHistoryTransactionReply struct {
@@ -158,7 +190,7 @@ func NewExGetHistoryTransaction(req *ExGetHistoryTransactionRequest) *ExGetHisto
 	obj.reqHeader.SeqID = seqID()
 	obj.reqHeader.PacketType = 0x01
 	obj.reqHeader.Method = KMSG_EXHISTORYTRANSACTION
-	obj.request.Count = 0x78
+	// obj.request.Count = 0x78
 	if req != nil {
 		obj.applyRequest(req)
 	}
@@ -200,6 +232,7 @@ func (obj *ExGetHistoryTransaction) ParseResponse(header *RespHeader, data []byt
 		}
 		minutes := binary.LittleEndian.Uint16(data[pos : pos+2])
 		actionCode := binary.LittleEndian.Uint16(data[pos+14 : pos+16])
+		// fmt.Println(data[pos+10:pos+16], actionCode)
 		item := ExHistoryTransactionItem{
 			Time:   fmt.Sprintf("%02d:%02d", (minutes/60)%24, minutes%60),
 			Price:  binary.LittleEndian.Uint32(data[pos+2 : pos+6]),

--- a/proto/ex_kline.go
+++ b/proto/ex_kline.go
@@ -42,7 +42,8 @@ type ExKLineItem struct {
 	Close     float64
 	Amount    float64
 	Vol       uint32
-	Last      float64 // 昨收盘价
+	PreClose  float64 // 昨收价
+	LastClose float64 // 前收价
 	RisePrice float64 // 涨跌价
 	RiseRate  float64 // 涨跌幅
 }
@@ -94,7 +95,7 @@ func (obj *ExGetKLine) ParseResponse(header *RespHeader, data []byte) error {
 	obj.reply.Count = binary.LittleEndian.Uint16(data[18:20])
 	pos := 20
 
-	var lastRaw float64 // 昨收盘价
+	var preCloseRaw float64 // 昨收盘价
 
 	for i := uint16(0); i < obj.reply.Count; i++ {
 		if pos+32 > len(data) {
@@ -114,8 +115,9 @@ func (obj *ExGetKLine) ParseResponse(header *RespHeader, data []byte) error {
 			Amount:   float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+20 : pos+24]))),
 			Vol:      binary.LittleEndian.Uint32(data[pos+24 : pos+28]),
 		}
-		item.Last = float64(lastRaw)
-		lastRaw = float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+16 : pos+20])))
+		item.PreClose = float64(preCloseRaw)
+		item.LastClose = float64(preCloseRaw)
+		preCloseRaw = float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+16 : pos+20])))
 		item.RiseRate = item.GetRiseRate()
 		item.RisePrice = item.GetRisePrice()
 		pos += 32
@@ -129,19 +131,19 @@ func (obj *ExGetKLine) ParseResponse(header *RespHeader, data []byte) error {
 }
 
 func (bar ExKLineItem) GetRisePrice() float64 {
-	if bar.Last == 0 {
+	if bar.PreClose == 0 {
 		//稍微数据准确点，没减去0这么夸张，还是不准的
 		return bar.Close - bar.Open
 	}
-	return bar.Close - bar.Last
+	return bar.Close - bar.PreClose
 }
 
 // RiseRate 涨跌比例/涨跌幅
 func (bar ExKLineItem) GetRiseRate() float64 {
-	if bar.Last == 0 {
+	if bar.PreClose == 0 {
 		return float64(bar.Close-bar.Open) / float64(bar.Open) * 100
 	}
-	return float64(bar.Close-bar.Last) / float64(bar.Last) * 100
+	return float64(bar.Close-bar.PreClose) / float64(bar.PreClose) * 100
 }
 
 func (obj *ExGetKLine) Response() *ExGetKLineReply {

--- a/proto/ex_protocol_test.go
+++ b/proto/ex_protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"math"
 	"testing"
+	"time"
 )
 
 func readExReqHeader(t *testing.T, raw []byte) exReqHeader {
@@ -443,7 +444,7 @@ func TestExGetKLineBuildRequestAndParseResponse(t *testing.T) {
 	if reply.Count != 1 || len(reply.List) != 1 {
 		t.Fatalf("unexpected reply: %+v", reply)
 	}
-	if reply.List[0].DateTime[:10] != "2026-03-31" || reply.List[0].Vol != 8888 {
+	if reply.List[0].DateTime.Format(time.DateOnly) != "2026-03-31" || reply.List[0].Vol != 8888 {
 		t.Fatalf("unexpected kline item: %+v", reply.List[0])
 	}
 }

--- a/proto/experimental.go
+++ b/proto/experimental.go
@@ -591,7 +591,7 @@ func (obj *ExGetKLine2) ParseResponse(header *RespHeader, data []byte) error {
 			return fmt.Errorf("invalid ex kline2 datetime: %d", dateNum)
 		}
 		item := ExKLineItem{
-			DateTime: ts.Format("2006-01-02 15:04:05"),
+			DateTime: ts,
 			Open:     float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+4 : pos+8]))),
 			High:     float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+8 : pos+12]))),
 			Low:      float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+12 : pos+16]))),

--- a/proto/experimental_protocol_test.go
+++ b/proto/experimental_protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"math"
 	"testing"
+	"time"
 )
 
 func TestRawMainProtocolBuildRequestAndParseResponse(t *testing.T) {
@@ -290,7 +291,7 @@ func TestExExperimentalMessagesBuildRequestAndParseResponse(t *testing.T) {
 		if reply.Name != "Tesla" || reply.Count != 1 || len(reply.List) != 1 {
 			t.Fatalf("unexpected reply: %+v", reply)
 		}
-		if reply.List[0].DateTime != "2026-04-11 15:00:00" || math.Abs(reply.List[0].Close-10.5) > 0.001 {
+		if reply.List[0].DateTime.Format(time.DateTime) != "2026-04-11 15:00:00" || math.Abs(reply.List[0].Close-10.5) > 0.001 {
 			t.Fatalf("unexpected item: %+v", reply.List[0])
 		}
 	})

--- a/proto/get_index_bars.go
+++ b/proto/get_index_bars.go
@@ -31,7 +31,8 @@ type GetIndexBarsReply struct {
 }
 
 type IndexBar struct {
-	Last      float64
+	PreClose  float64 // 昨收价
+	LastClose float64 // 前收价
 	RisePrice float64 // 涨跌价
 	RiseRate  float64 // 涨跌幅
 	Open      float64
@@ -94,7 +95,7 @@ func (obj *GetIndexBars) ParseResponse(header *RespHeader, data []byte) error {
 		return err
 	}
 	pos += 2
-	var lastRaw int // 昨收盘价
+	var preCloseRaw int // 昨收盘价
 	for index := uint16(0); index < obj.reply.Count; index++ {
 		var dateNum uint32
 		if err := binary.Read(bytes.NewBuffer(data[pos:pos+4]), binary.LittleEndian, &dateNum); err != nil {
@@ -130,10 +131,11 @@ func (obj *GetIndexBars) ParseResponse(header *RespHeader, data []byte) error {
 			Minute:   dateTime.Minute(),
 			DateTime: dateTime,
 		}
-		bar.Last = float64(lastRaw) / 1000.0
+		bar.PreClose = float64(preCloseRaw) / 1000.0
+		bar.LastClose = float64(preCloseRaw) / 1000.0
 		bar.RiseRate = bar.GetRiseRate()
 		bar.RisePrice = bar.GetRisePrice()
-		lastRaw = closeRaw
+		preCloseRaw = closeRaw
 
 		if pos+4 <= len(data) {
 			tryDateNum := binary.LittleEndian.Uint32(data[pos : pos+4])
@@ -155,19 +157,19 @@ func (obj *GetIndexBars) ParseResponse(header *RespHeader, data []byte) error {
 }
 
 func (bar IndexBar) GetRisePrice() float64 {
-	if bar.Last == 0 {
+	if bar.PreClose == 0 {
 		//稍微数据准确点，没减去0这么夸张，还是不准的
 		return bar.Close - bar.Open
 	}
-	return bar.Close - bar.Last
+	return bar.Close - bar.PreClose
 }
 
 // RiseRate 涨跌比例/涨跌幅
 func (bar IndexBar) GetRiseRate() float64 {
-	if bar.Last == 0 {
+	if bar.PreClose == 0 {
 		return float64(bar.Close-bar.Open) / float64(bar.Open) * 100
 	}
-	return float64(bar.Close-bar.Last) / float64(bar.Last) * 100
+	return float64(bar.Close-bar.PreClose) / float64(bar.PreClose) * 100
 }
 
 func (obj *GetIndexBars) Response() *GetIndexBarsReply {

--- a/proto/get_security_bars.go
+++ b/proto/get_security_bars.go
@@ -31,7 +31,8 @@ type GetSecurityBarsReply struct {
 }
 
 type SecurityBar struct {
-	Last      float64   // 昨收盘价
+	PreClose  float64   // 昨收价
+	LastClose float64   // 前收价
 	Open      float64   // 开盘价。
 	Close     float64   // 收盘价。
 	High      float64   // 最高价。
@@ -99,7 +100,7 @@ func (obj *GetSecurityBars) ParseResponse(header *RespHeader, data []byte) error
 	}
 	pos += 2
 
-	var lastRaw int // 昨收盘价
+	var preCloseRaw int // 昨收盘价
 	for index := uint16(0); index < obj.reply.Count; index++ {
 		var dateNum uint32
 		if err := binary.Read(bytes.NewBuffer(data[pos:pos+4]), binary.LittleEndian, &dateNum); err != nil {
@@ -116,7 +117,7 @@ func (obj *GetSecurityBars) ParseResponse(header *RespHeader, data []byte) error
 
 		openRaw = getprice(data, &pos)
 		if isOffsetReq {
-			openRaw = lastRaw + openRaw
+			openRaw = preCloseRaw + openRaw
 			closeRaw = getprice(data, &pos) + openRaw
 			highRaw = getprice(data, &pos) + openRaw
 			lowRaw = getprice(data, &pos) + openRaw
@@ -143,8 +144,9 @@ func (obj *GetSecurityBars) ParseResponse(header *RespHeader, data []byte) error
 			Minute:   dateTime.Minute(),
 			DateTime: dateTime,
 		}
-		bar.Last = float64(lastRaw) / 1000.0
-		lastRaw = closeRaw
+		bar.PreClose = float64(preCloseRaw) / 1000.0
+		bar.LastClose = float64(preCloseRaw) / 1000.0
+		preCloseRaw = closeRaw
 
 		bar.RiseRate = bar.GetRiseRate()
 		bar.RisePrice = bar.GetRisePrice()
@@ -169,19 +171,19 @@ func (obj *GetSecurityBars) ParseResponse(header *RespHeader, data []byte) error
 }
 
 func (bar SecurityBar) GetRisePrice() float64 {
-	if bar.Last == 0 {
+	if bar.PreClose == 0 {
 		//稍微数据准确点，没减去0这么夸张，还是不准的
 		return bar.Close - bar.Open
 	}
-	return bar.Close - bar.Last
+	return bar.Close - bar.PreClose
 }
 
 // RiseRate 涨跌比例/涨跌幅
 func (bar SecurityBar) GetRiseRate() float64 {
-	if bar.Last == 0 {
+	if bar.PreClose == 0 {
 		return float64(bar.Close-bar.Open) / float64(bar.Open) * 100
 	}
-	return float64(bar.Close-bar.Last) / float64(bar.Last) * 100
+	return float64(bar.Close-bar.PreClose) / float64(bar.PreClose) * 100
 }
 
 func (obj *GetSecurityBars) Response() *GetSecurityBarsReply {

--- a/proto/mac_symbol_bars.go
+++ b/proto/mac_symbol_bars.go
@@ -68,7 +68,8 @@ type MACSymbolBar struct {
 	Vol         float64
 	FloatShares float64
 	Turnover    float64
-	Last        float64
+	PreClose    float64 // 昨收价
+	LastClose   float64 // 前收价
 	RisePrice   float64 // 涨跌价
 	RiseRate    float64 // 涨跌幅
 }
@@ -134,7 +135,7 @@ func (obj *MACSymbolBars) ParseResponse(header *RespHeader, data []byte) error {
 
 	formatTDXTime := obj.reply.Period < 4 || obj.reply.Period == 7 || obj.reply.Period == 8
 	pos := 33
-	var lastRaw float64 // 昨收盘价
+	var preCloseRaw float64 // 昨收盘价
 	for i := uint16(0); i < obj.reply.Count; i++ {
 		if pos+36 > len(data) {
 			return fmt.Errorf("invalid mac symbol bar item %d", i)
@@ -151,8 +152,9 @@ func (obj *MACSymbolBars) ParseResponse(header *RespHeader, data []byte) error {
 			Vol:         float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+28 : pos+32]))),
 			FloatShares: float64(math.Float32frombits(binary.LittleEndian.Uint32(data[pos+32 : pos+36]))),
 		}
-		item.Last = lastRaw
-		lastRaw = item.Close
+		item.PreClose = preCloseRaw
+		item.LastClose = preCloseRaw
+		preCloseRaw = item.Close
 		item.RiseRate = item.GetRiseRate()
 		item.RisePrice = item.GetRisePrice()
 		pos += 36
@@ -191,19 +193,19 @@ func (obj *MACSymbolBars) ParseResponse(header *RespHeader, data []byte) error {
 }
 
 func (bar MACSymbolBar) GetRisePrice() float64 {
-	if bar.Last == 0 {
+	if bar.PreClose == 0 {
 		//稍微数据准确点，没减去0这么夸张，还是不准的
 		return bar.Close - bar.Open
 	}
-	return bar.Close - bar.Last
+	return bar.Close - bar.PreClose
 }
 
 // RiseRate 涨跌比例/涨跌幅
 func (bar MACSymbolBar) GetRiseRate() float64 {
-	if bar.Last == 0 {
+	if bar.PreClose == 0 {
 		return (bar.Close - bar.Open) / (bar.Open) * 100
 	}
-	return (bar.Close - bar.Last) / (bar.Last) * 100
+	return (bar.Close - bar.PreClose) / (bar.PreClose) * 100
 }
 
 func (obj *MACSymbolBars) Response() *MACSymbolBarsReply {


### PR DESCRIPTION
- 将ExKLineItem结构体中的DateTime字段从string类型改为time.Time类型
- 新增Last(昨收盘价)、RisePrice(涨跌价)、RiseRate(涨跌幅)字段
- 实现GetRisePrice和GetRiseRate方法来计算涨跌数据
- 修改解析逻辑以正确处理新增字段并跳过第一条记录(作为基准)

fix(webviewer): 更新K线查询接口返回昨收盘价字段

- 在webviewer的runMethod函数中将columns添加"last"字段到第二位
- 在rowsFromExKLine函数中格式化time.Time为标准时间字符串
- 使用formatFloat函数格式化新增的Last字段数值

chore(examples): 更新示例代码使用上证指数数据

- 将StockIndexInfo、StockIndexMomentum、GetIndexBars等接口 从深证399001改为上证000001进行测试
- 确保示例代码与更新后的API接口兼容

refactor(proto): 调整历史交易请求参数并修复解析逻辑

- 注释掉ExGetHistoryTransactionRequest中的Start字段说明
- 移除默认Count值设置，允许用户自定义
- 清理调试用的打印语句