### PR TITLE
fix(proto): 39xx 指数 baseUnit 使用 100，保证逐笔和分时一致

### DIFF
--- a/proto/proto.go
+++ b/proto/proto.go
@@ -484,7 +484,7 @@ func getvolume(ivol int) (volume float64) {
 
 func baseUnit(code string) float64 {
 	switch code[:2] {
-	case "60", "30", "68", "00":
+	case "60", "30", "68", "00", "39":
 		return 100.0
 	default:
 		return 1000.0

--- a/proto/protocol_test.go
+++ b/proto/protocol_test.go
@@ -1454,3 +1454,23 @@ func TestDownloadFileBuildRequestAndParseResponse(t *testing.T) {
 		t.Fatalf("unexpected download reply: %+v", msg.Response())
 	}
 }
+
+func TestBaseUnitUsesHundredForShenZhenIndexPrefix(t *testing.T) {
+	cases := []struct {
+		code string
+		want float64
+	}{
+		{code: "000001", want: 100},
+		{code: "600000", want: 100},
+		{code: "300750", want: 100},
+		{code: "688001", want: 100},
+		{code: "399001", want: 100},
+		{code: "399006", want: 100},
+		{code: "510300", want: 1000},
+	}
+	for _, tc := range cases {
+		if got := baseUnit(tc.code); got != tc.want {
+			t.Fatalf("baseUnit(%q) = %v, want %v", tc.code, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `baseUnit` 为深市指数前缀 `39` 返回 `100`（与 `00/30/60/68` 一致）
- 修复 `399001` 等历史逐笔价格相对分时偏小 10 倍的问题
- 补充 `baseUnit` 单测（含 `000001` 正常、`399001`/`399006` 修正后、ETF `510300` 仍为 1000）

Fixes #37

## 原因

```go
// 修改前：39 走 default → 1000
case "60", "30", "68", "00":
    return 100.0
```

上证指数 `000001` 前缀 `00` 本就正确；深证成指 `399001` 前缀 `39` 被误除 1000。

## Test plan

- [x] `go test ./proto -run TestBaseUnitUsesHundredForShenZhenIndexPrefix`
- [x] 用 `GetHistoryTransactionData(date, 0, "399001")` 与同日 `GetHistoryMinuteTimeData` 对比价格量级应一致